### PR TITLE
Make FileSystem/DB part a bit easier to use as a library

### DIFF
--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/schollz/rwtxt"
 	"github.com/schollz/rwtxt/pkg/db"
 )


### PR DESCRIPTION
I made the following general changes for the general reasons:

1. Exposed both `Name` and `DB` in `db.FileSystem` - This allows people to instantiate and use the `FileSystem` struct without going through `New` explicitly. This means people can use it inside other Sqlite databases including ones they've already opened (sync.RWMutex was already exposed).
1. Exposed `InitializeDB` in `db.FileSystem` and added option to not do a SQL dump - This allows people to initialize the DB outside of calling `New` and allows them to turn off the default dump that occurs.
1. Move the "github.com/mattn/go-sqlite3" import from `db.go` to `main.go` - This allows people to create the driver in other ways or just not use that driver at all if they do something instead of calling `New`.

These changes should be fairly minimal. For my use cases, I refrained from making the following changes:

* Make the dump feature optional in `rwtxt.go` (really I was gonna make it configurable frequency w/ 0 meaning disabled) - It only happens in `Serve` and due to the great work previously of exposing the `Handler`, I can just skip `Serve` altogether
* Remove that `go-sqlite3` import from `dump.go` in https://github.com/schollz/sqlite3dump - I can just vendor and stub out the call since I don't want the DB dumped

Now, here are the real reasons for my changes :-)

* I made a version at https://github.com/cretz/rwtxt-crypt that uses an encrypted Sqlite DB and exposes it over a Tor onion service (quite awesome, works beautifully, I am `kodablah` on HN that made the comment that I was gonna do this)
* I needed to use https://github.com/cretz/go-sqleet instead of https://github.com/mattn/go-sqlite3, but both cannot be compiled into the same binary due to name conflicts
* I do not want the sqlite DB to be dumped ever, it doesn't fit into the security model

Let me know if there are any reservations about what I've done or if you want to solve some of my use-case requirements another way.