### PR TITLE
Add support for private installations where search and listing are allowed for public domain

### DIFF
--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/schollz/rwtxt"
 	"github.com/schollz/rwtxt/pkg/db"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -26,6 +26,7 @@ func main() {
 		profileMemory = flag.Bool("memprofile", false, "profile memory")
 		database      = flag.String("db", "rwtxt.db", "name of the database")
 		listen        = flag.String("listen", rwtxt.DefaultBind, "interface:port to listen on")
+		private       = flag.Bool("private", false, "private setup (allows listing of public notes)")
 	)
 	flag.Parse()
 
@@ -66,7 +67,9 @@ func main() {
 		panic(err)
 	}
 
-	rwt, err := rwtxt.New(fs)
+	config := rwtxt.Config{Private: *private}
+
+	rwt, err := rwtxt.New(fs, config)
 	if err != nil {
 		panic(err)
 	}

--- a/template_render.go
+++ b/template_render.go
@@ -24,34 +24,35 @@ const introText = "This note is empty. Click to edit it."
 var languageCSS map[string]string
 
 type TemplateRender struct {
-	Title             string
-	Page              string
-	Rendered          template.HTML
-	File              db.File
-	IntroText         template.JS
-	Rows              int
-	RandomUUID        string
-	Domain            string
-	DomainID          int
-	DomainKey         string
-	DomainIsPrivate   bool
-	DomainValue       template.HTMLAttr
-	DomainList        []string
-	DomainKeys        map[string]string
-	DefaultDomain     string
-	SignedIn          bool
-	Message           string
-	NumResults        int
-	Files             []db.File
-	MostActiveList    []db.File
-	SimilarFiles      []db.File
-	Search            string
-	DomainExists      bool
-	ShowCookieMessage bool
-	EditOnly          bool
-	Languages         []string
-	LanguageJS        []template.JS
-	rwt               *RWTxt
+	Title              string
+	Page               string
+	Rendered           template.HTML
+	File               db.File
+	IntroText          template.JS
+	Rows               int
+	RandomUUID         string
+	Domain             string
+	DomainID           int
+	DomainKey          string
+	DomainIsPrivate    bool
+	PrivateEnvironment bool
+	DomainValue        template.HTMLAttr
+	DomainList         []string
+	DomainKeys         map[string]string
+	DefaultDomain      string
+	SignedIn           bool
+	Message            string
+	NumResults         int
+	Files              []db.File
+	MostActiveList     []db.File
+	SimilarFiles       []db.File
+	Search             string
+	DomainExists       bool
+	ShowCookieMessage  bool
+	EditOnly           bool
+	Languages          []string
+	LanguageJS         []template.JS
+	rwt                *RWTxt
 }
 
 type Payload struct {
@@ -199,7 +200,8 @@ func (tr *TemplateRender) handleMain(w http.ResponseWriter, r *http.Request, mes
 		signedin = false
 	}
 	tr.SignedIn = signedin
-	tr.DomainIsPrivate = !ispublic && tr.Domain != "public"
+	tr.DomainIsPrivate = !ispublic && (tr.Domain != "public" || tr.rwt.config.Private)
+	tr.PrivateEnvironment = tr.rwt.config.Private
 	tr.DomainExists = domainErr == nil
 	tr.Files, err = tr.rwt.fs.GetTopX(tr.Domain, 10)
 	if err != nil {

--- a/templates/main.html
+++ b/templates/main.html
@@ -17,7 +17,7 @@
 
 	<h1>{{if eq .Domain "public"}}Welcome{{else}}{{.Domain}}{{end}}</h1>
 	
-	{{if eq .Domain "public"}}
+	{{if and (eq .Domain "public") (not .PrivateEnvironment)}}
 	<p>This is <em>rwtxt</em>, a space for <em>reading and writing text</em> which you can use	as a blog, a pastebin, or a notepad.
 	</p>
 	{{end}}
@@ -46,7 +46,7 @@
 	<p>Write your rwtxt <a href="/{{.Domain}}/{{.RandomUUID}}">here</a>.</p>
 	{{end}}
 
-	{{ if and (or (not .DomainIsPrivate) (.SignedIn)) (ne .Domain "public") }}
+	{{ if and (or (not .DomainIsPrivate) (.SignedIn)) (or (ne .Domain "public") (.PrivateEnvironment)) }}
 	{{ if .Files }}
 	<h2>Most recent <small>(<a href="/{{.Domain}}/list">all posts</a>)</small></h2>
 	<ul>


### PR DESCRIPTION
This PR adds `--private` flag that allows to run rwtxt in "Private environment" mode. 
In this mode it's allowed to list and search public domain.
It's useful for installations on localhost or in local network