### PR TITLE
Show not saved icon if socket is disconnected

### DIFF
--- a/static/js/rwtxt.js
+++ b/static/js/rwtxt.js
@@ -6,6 +6,7 @@ const socketMessageListener = (event) => {
 };
 const socketOpenListener = (event) => {
     // console.log('Connected');
+    document.getElementById("notsaved").style.display = 'none';
     document.getElementById("connectedicon").style.display = 'inline-block';
     setTimeout(function () {
         document.getElementById("connectedicon").style.display = 'none';
@@ -14,6 +15,7 @@ const socketOpenListener = (event) => {
 const socketCloseListener = (event) => {
     if (socket) {
         console.error('Disconnected.');
+        document.getElementById("notsaved").style.display = 'inline-block';
     }
     var url = window.origin.replace("http", "ws") + '/ws';
     socket = new WebSocket(url);


### PR DESCRIPTION
Currently if editing and the web socket disconnects for any reason there is no feedback that your keystrokes aren't being saved except for the absence of the tick in the corner. This change displays the not-connected symbol (❌) if the socket has disconnected. It is left visible until the connection is re-established.