### PR TITLE
adds automatic image resizer

### DIFF
--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -23,7 +23,7 @@ func main() {
 		err              error
 		debug            = flag.Bool("debug", false, "debug mode")
 		showVersion      = flag.Bool("v", false, "show version")
-		resizeImageWidth = flag.Int("resizeimages", -1, "image width to resize")
+		resizeImageWidth = flag.Int("resizeimagewidth", -1, "image width to resize")
 		profileMemory    = flag.Bool("memprofile", false, "profile memory")
 		database         = flag.String("db", "rwtxt.db", "name of the database")
 		listen           = flag.String("listen", rwtxt.DefaultBind, "interface:port to listen on")

--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/schollz/rwtxt"
 	"github.com/schollz/rwtxt/pkg/db"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -20,13 +20,14 @@ var (
 
 func main() {
 	var (
-		err           error
-		debug         = flag.Bool("debug", false, "debug mode")
-		showVersion   = flag.Bool("v", false, "show version")
-		profileMemory = flag.Bool("memprofile", false, "profile memory")
-		database      = flag.String("db", "rwtxt.db", "name of the database")
-		listen        = flag.String("listen", rwtxt.DefaultBind, "interface:port to listen on")
-		private       = flag.Bool("private", false, "private setup (allows listing of public notes)")
+		err              error
+		debug            = flag.Bool("debug", false, "debug mode")
+		showVersion      = flag.Bool("v", false, "show version")
+		resizeImageWidth = flag.Int("resizeimages", -1, "image width to resize")
+		profileMemory    = flag.Bool("memprofile", false, "profile memory")
+		database         = flag.String("db", "rwtxt.db", "name of the database")
+		listen           = flag.String("listen", rwtxt.DefaultBind, "interface:port to listen on")
+		private          = flag.Bool("private", false, "private setup (allows listing of public notes)")
 	)
 	flag.Parse()
 
@@ -67,7 +68,7 @@ func main() {
 		panic(err)
 	}
 
-	config := rwtxt.Config{Private: *private}
+	config := rwtxt.Config{Private: *private, ResizeImageWidth: *resizeImageWidth}
 
 	rwt, err := rwtxt.New(fs, config)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/schollz/rwtxt
 require (
 	github.com/DavidBelicza/TextRank v2.1.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
+	github.com/disintegration/imaging v1.5.0
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/gorilla/websocket v1.4.0
@@ -21,6 +22,7 @@ require (
 	github.com/tdewolff/minify v2.3.6+incompatible // indirect
 	github.com/tdewolff/parse v2.3.3+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
+	golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b // indirect
 	golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3 // indirect
 	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.0

--- a/rwtxt.go
+++ b/rwtxt.go
@@ -27,17 +27,20 @@ type RWTxt struct {
 	prismTemplate    []string
 	fs               *db.FileSystem
 	wsupgrader       websocket.Upgrader
+	resizeImageWidth int
 }
 
 type Config struct {
-	Private bool
+	Private          bool
+	ResizeImageWidth int
 }
 
 func New(fs *db.FileSystem, config Config) (*RWTxt, error) {
 	rwt := &RWTxt{
-		Bind:   DefaultBind,
-		fs:     fs,
-		config: config,
+		Bind:             DefaultBind,
+		fs:               fs,
+		config:           config,
+		resizeImageWidth: config.ResizeImageWidth,
 		wsupgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,


### PR DESCRIPTION
This pull request creates an option that allows on the fly image resizing before serving back to the front-end.

This will make it useful for people like myself who wish to maintain blogs on rwtxt that have many uploaded images. The automatic resizing will ensure a good user experience as the pages will load much faster.

Original images are stored, and the resized counterparts are cached in the `cached_images` table.

On startup, the cached_images table will be dropped then recreated.

With `go run cmd/rwtxt/*.go -debug`

![1](https://user-images.githubusercontent.com/4482567/49660528-c9502c80-fa81-11e8-9070-dab0e0be9c86.png)

With `go run cmd/rwtxt/*.go -debug -resizeimagewidth 300`

![2](https://user-images.githubusercontent.com/4482567/49660541-cd7c4a00-fa81-11e8-9632-8984b817eec4.png)

- Original image is 70.6kB
- Resized image is 6.3kB

Removing the `-resizeimagewidth` flag will bring back the full sized images.