### PR TITLE
adds ability to export posts and uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@
 *.out
 
 # Intermediate build artifacts
+/*.zip
 /assets
 /bindata.go
 /go.sum
+/vendor
 
 # RWTxt databases
 *db

--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/schollz/rwtxt"
 	"github.com/schollz/rwtxt/pkg/db"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -21,6 +21,7 @@ var (
 func main() {
 	var (
 		err           error
+		export        = flag.Bool("export", false, "export uploads to {{TIMESTAMP}}-uploads.zip and posts to {{TIMESTAMP}}-posts.zip")
 		debug         = flag.Bool("debug", false, "debug mode")
 		showVersion   = flag.Bool("v", false, "show version")
 		profileMemory = flag.Bool("memprofile", false, "profile memory")
@@ -65,6 +66,18 @@ func main() {
 	fs, err := db.New(dbName)
 	if err != nil {
 		panic(err)
+	}
+
+	if *export {
+		err = fs.ExportPosts()
+		if err != nil {
+			panic(err)
+		}
+		err = fs.ExportUploads()
+		if err != nil {
+			panic(err)
+		}
+		return
 	}
 
 	config := rwtxt.Config{Private: *private}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,11 +1,14 @@
 package utils
 
 import (
+	"archive/zip"
 	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/hex"
 	"html/template"
+	"io"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -14,6 +17,56 @@ import (
 	blackfriday "gopkg.in/russross/blackfriday.v2"
 )
 
+// ZipFiles will zip files to filename
+func ZipFiles(filename string, files []string) error {
+
+	newZipFile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer newZipFile.Close()
+
+	zipWriter := zip.NewWriter(newZipFile)
+	defer zipWriter.Close()
+
+	// Add files to zip
+	for _, file := range files {
+
+		zipfile, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer zipfile.Close()
+
+		// Get the file information
+		info, err := zipfile.Stat()
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		// Using FileInfoHeader() above only uses the basename of the file. If we want
+		// to preserve the folder structure we can overwrite this with the full path.
+		header.Name = file
+
+		// Change to deflate to gain better compression
+		// see http://golang.org/pkg/archive/zip/#pkg-constants
+		header.Method = zip.Deflate
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		if _, err = io.Copy(writer, zipfile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func RenderMarkdownToHTML(markdown string) template.HTML {
 	html := string(blackfriday.Run([]byte(markdown),
 		blackfriday.WithExtensions(


### PR DESCRIPTION
I was concerned about my blobs/image uploads being trapped inside the system, so I made this pull request.

It adds an `-export` flag, which will create a zip of all posts (inside folders named after their parent domains). It will also create another zip of all attachments named with the concatenated SHA256 hash and filename to preserve information if the data needs to be rebuilt. 

`time.Now().UnixNano()` is used for the zip filenames, just in case we are still using `rwtxt` after 2038 ;)