### PR TITLE
adds dumponstart flag to allow config of dumping db on start

### DIFF
--- a/cmd/rwtxt/main.go
+++ b/cmd/rwtxt/main.go
@@ -21,6 +21,7 @@ var (
 func main() {
 	var (
 		err             error
+		dumpOnStart     = flag.Bool("dumponstart", false, "Dump database to gz file on start")
 		export          = flag.Bool("export", false, "export uploads to {{TIMESTAMP}}-uploads.zip and posts to {{TIMESTAMP}}-posts.zip")
 		resizeWidth     = flag.Int("resizewidth", -1, "image width to resize on the fly")
 		resizeOnUpload  = flag.Bool("resizeonupload", false, "resize on upload")
@@ -67,7 +68,7 @@ func main() {
 	dbName = *database
 	defer log.Flush()
 
-	fs, err := db.New(dbName)
+	fs, err := db.New(dbName, *dumpOnStart)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
+	github.com/karalabe/xgo v0.0.0-20181007145344-72da7d1d3970 // indirect
 	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 // indirect
 	github.com/mattn/go-sqlite3 v1.9.0
 	github.com/microcosm-cc/bluemonday v1.0.1

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -45,7 +45,7 @@ type File struct {
 // New will initialize a filesystem by creating DB and calling InitializeDB.
 // Callers should ensure "github.com/mattn/go-sqlite3" is imported in some way
 // before calling this so the sqlite3 driver is available.
-func New(name string) (fs *FileSystem, err error) {
+func New(name string, dumpOnStart bool) (fs *FileSystem, err error) {
 	fs = new(FileSystem)
 	if name == "" {
 		err = errors.New("database must have name")
@@ -57,7 +57,7 @@ func New(name string) (fs *FileSystem, err error) {
 	if err != nil {
 		return
 	}
-	err = fs.InitializeDB(true)
+	err = fs.InitializeDB(dumpOnStart)
 	if err != nil {
 		err = errors.Wrap(err, "could not initialize")
 		return


### PR DESCRIPTION
This was previously hardcoded to "true". For large databases or slow machines this adds quite a long startup time. I've changed it to be customisable.