### PR TITLE
allow batch uploads of images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+rwtxt
 *.exe
 *.exe~
 *.dll

--- a/static/js/rwtxt.js
+++ b/static/js/rwtxt.js
@@ -229,15 +229,18 @@ function onUploadFinished(file) {
         file.xhr.getResponseHeader("Location") +
         ')';
 
+    var newLine = "\n"
     document.getElementById("editable").value = (
         textBefore +
-        extraText +
+        extraText + 
+        newLine +
         textAfter
     );
 
+    console.log("SELECT LINK")
     // Select the newly-inserted link
-    document.getElementById("editable").selectionStart = cursorPos;
-    document.getElementById("editable").selectionEnd = cursorPos + extraText.length;
+    document.getElementById("editable").selectionStart = cursorPos + extraText.length + newLine.length;
+    document.getElementById("editable").selectionEnd = cursorPos + extraText.length + newLine.length;
    // expand textarea
     autoExpand(document.getElementById("editable"));
    // trigger a save


### PR DESCRIPTION
Previously, the image that was uploaded was being selected. This means that subsequent images will overwrite the previous images.

This patch allows us to upload a large number of images at once, and as they complete uploading they will append rather than replace the markdown link.