### PR TITLE
adds doNotDump flags, refactors orderBy and adds orderBySlug

### DIFF
--- a/template_render.go
+++ b/template_render.go
@@ -271,11 +271,11 @@ func (tr *TemplateRender) handleMain(w http.ResponseWriter, r *http.Request) (er
 		tr.Options.MostRecent = 10
 		tr.Options.MostEdited = 10
 	}
-	tr.Files, err = tr.rwt.fs.GetTopX(tr.Domain, tr.Options.MostRecent, tr.RWTxtConfig.OrderByCreated)
+	tr.Files, err = tr.rwt.fs.GetTopX(tr.Domain, tr.Options.MostRecent, tr.RWTxtConfig.OrderBy)
 	if err != nil {
 		log.Debug(err)
 	}
-	tr.AllFiles, err = tr.rwt.fs.GetAll(tr.Domain, true)
+	tr.AllFiles, err = tr.rwt.fs.GetAll(tr.Domain, tr.RWTxtConfig.OrderBy)
 	if err != nil {
 		log.Debug(err)
 	}
@@ -920,7 +920,7 @@ func (tr *TemplateRender) handleExport(w http.ResponseWriter, r *http.Request) (
 		http.Redirect(w, r, "/"+tr.Domain+"?m="+base64.URLEncoding.EncodeToString([]byte("must sign in")), 302)
 		return
 	}
-	files, _ := tr.rwt.fs.GetAll(tr.Domain, tr.RWTxtConfig.OrderByCreated)
+	files, _ := tr.rwt.fs.GetAll(tr.Domain, tr.RWTxtConfig.OrderBy)
 	for i := range files {
 		files[i].DataHTML = template.HTML("")
 	}

--- a/templates/list.html
+++ b/templates/list.html
@@ -14,7 +14,7 @@
 						<a href="/{{$.Domain}}/{{.ID}}">{{.Slug}}</a>
 				</div>
 				<div>
-						{{ if $.RWTxtConfig.OrderByCreated}}{{.CreatedDate $.UTCOffset}}{{else}}{{.ModifiedDate $.UTCOffset}}{{end}}
+						{{ if eq $.RWTxtConfig.OrderBy 3}}{{.CreatedDate $.UTCOffset}}{{else}}{{.ModifiedDate $.UTCOffset}}{{end}}
                 </div>
                 {{with .DataHTML}}<blockquote><em>{{.}}</em></blockquote>{{end}}
 			</div>


### PR DESCRIPTION
My deployment of rwtxt kept hitting OOM errors as it dumps the entire DB everytime as I have 11 years of images and blog posts stored on there. 

I tried to make the default behaviour the same as it was before this pull request. But you now have flags to help with this.
```
-donotdumponstart
-donotdumponchange
```

My blog posts also have orderable slugs, for example:
```
2018-01-14-baz
2018-01-09-bar
2018-01-08-foo
```

To enable this I have refactored the `orderBy` functionality to be an enum (using `iota`s) instead of a variadic argument (i.e. `created... bool`)
