### PR TITLE
Repair run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ exec: prereq bundle
 
 quick: bundle
 	go-bindata -pkg rwtxt -nocompress assets assets/img assets/js assets/css assets/img/favicon
-	cd cmd/rwtxt && go build -v --tags "fts4" ${LDFLAGS} && cp rwtxt ../../
+	go build -v --tags "fts4" ${LDFLAGS} ./cmd/rwtxt
 
-run: build
-	$(GOPATH)/bin/rwtxt
+run: quick
+	./rwtxt
 
 debug: 
 	go get -v --tags "fts4" ${LDFLAGS} ./...


### PR DESCRIPTION
The target depended on build which was removed in
b4d471ed4a8b28a048fcf62eb79eeffe0d1e9ba8 to compile the binary.
Now the run target requires on quick which builds the binary as well.
Also, I removed the redundant cding into cmd/rwtxt because the path can
be passed to go build.

Note that quick should be renamed to rwtxt because this is the file the
target produces.  But, this change is outside the scope of this PR.